### PR TITLE
US 105 

### DIFF
--- a/config/keller_und_knilche.sql
+++ b/config/keller_und_knilche.sql
@@ -29,7 +29,7 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `beute_batzen` (
   `user_id` int(11) NOT NULL,
-  `amount` bigint(50) DEFAULT 0
+  `amount` double DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------

--- a/config/keller_und_knilche.sql
+++ b/config/keller_und_knilche.sql
@@ -29,7 +29,7 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `beute_batzen` (
   `user_id` int(11) NOT NULL,
-  `amount` double DEFAULT 0
+  `amount` DECIMAL(65,2) NOT NULL DEFAULT 0.00
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------

--- a/src/api/register_click.php
+++ b/src/api/register_click.php
@@ -62,8 +62,8 @@ $newTotalAmount = getCurrentCurrency($db, $userId); // Diese Funktion existiert 
 
 // 4. Erfolgsantwort mit neuem Betrag senden
 echo json_encode([
-    'success' => true,
-    'newAmount' => $newTotalAmount // Unformatierter Rohwert
+    'success'   => true,
+    'newAmount' => round($newTotalAmount, 2)
 ]);
 
 ?>

--- a/src/api/register_click.php
+++ b/src/api/register_click.php
@@ -63,7 +63,7 @@ $newTotalAmount = getCurrentCurrency($db, $userId); // Diese Funktion existiert 
 // 4. Erfolgsantwort mit neuem Betrag senden
 echo json_encode([
     'success' => true,
-    'newAmount' => round($newTotalAmount, 2) // Runde für die Anzeige
+    'newAmount' => $newTotalAmount // Unformatierter Rohwert
 ]);
 
 ?>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -35,7 +35,6 @@ header {
 }
 
 .title {
-/* Nur eine font-family Definition */
     font-size: clamp(2rem, 5vw, 4rem); /* Dynamische Schriftgröße */
     font-weight: bold;
     letter-spacing: 2px;
@@ -46,12 +45,33 @@ header {
     padding: 0; /* Entferne Standard-Padding */
 }
 
+/* Currency display styling - cleaned up */
 .currency-display {
-    font-size: 1.2rem; /* Kleinere Schriftgröße für mobile Geräte */
+    font-size: 1.2rem;
     font-weight: bold;
     color: #ffd700;
-    margin-top: 10px;
+    padding: 8px 15px;
+    text-align: center;
+    margin: 10px auto;
+    width: fit-content;
+    max-width: 90%;
 }
+
+/* Currency container positioning - change these values to adjust position */
+.currency-container {
+    margin-top: 30px !important; /* Increase this value to move down, decrease to move up */
+    margin-bottom: 20px !important;
+}
+
+/* Remove the problematic fixed positioning */
+@media (min-width: 992px) {
+    .row.currency-container {
+        position: static;
+        margin-top: 15px; /* Adjust this value to change the Y positioning on desktop */
+        margin-bottom: 15px;
+    }
+}
+
 .stat-display {
     font-size: 1.2rem; /* Kleinere Schriftgröße für mobile Geräte */
     font-weight: bold;
@@ -296,7 +316,6 @@ body {
     margin-bottom: 0; 
   }
 
-
 /* Navbar Styling */
 .navbar {
     position: fixed; /* Fixiere die Navbar oben */
@@ -345,7 +364,6 @@ footer .nav-item {
     flex: 1 1 auto; /* Flexibles Verhalten für responsive Layouts */
     text-align: center;
 }
-
 
 /* Side Panels auf kleinen Schirmen */
 @media (max-width: 992px) {
@@ -455,7 +473,6 @@ footer .nav-item {
         top: 10px;
     }
 }
-
 
 /* Profil Styling */
 .profile-wrapper {
@@ -604,8 +621,6 @@ footer .nav-item {
 .upgrades-list div:hover {
     background-color: #84a98c;
 }
-
-
 
 /* Side Panels auf größeren Bildschirmen */
 @media (min-width: 992px) {

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -5,6 +5,35 @@ let penaltyEndTime = 0; // Zeitpunkt, zu dem die Strafe endet
 let upgrades = [];
 let updateInterval; // Variable für die Intervall-ID deklarieren
 
+// Hilfsfunktion zum Formatieren großer Zahlen
+function formatNumber(number) {
+    number = parseFloat(number);
+    
+    if (isNaN(number)) {
+        return '0.00';
+    }
+    
+    if (number >= 1000) {
+        const suffixes = ['', 'K', 'M', 'B', 'T', 'Q', 'Qi', 'Sx', 'Sp', 'Oc', 'No', 'Dc'];
+        let suffixIndex = 0;
+        
+        while (number >= 1000 && suffixIndex < suffixes.length - 1) {
+            number /= 1000;
+            suffixIndex++;
+        }
+        
+        return number.toLocaleString('de-DE', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        }) + suffixes[suffixIndex];
+    } else {
+        return number.toLocaleString('de-DE', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        });
+    }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     const clickButton = document.getElementById("click_button");
     if (clickButton) {
@@ -43,13 +72,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 const data = await response.json();
                 if (data.success) {
-                    currencyElement.textContent = parseFloat(data.newAmount)
-                        .toLocaleString('de-DE',{minimumFractionDigits:2,maximumFractionDigits:2});
-                    productionRateElement.textContent = data.productionPerSecond>0
-                        ? `(${parseFloat(data.productionPerSecond)
-                            .toLocaleString('de-DE',{minimumFractionDigits:2,maximumFractionDigits:2})} BB/s)`
+                    currencyElement.textContent = formatNumber(data.newAmount);
+                    productionRateElement.textContent = data.productionPerSecond > 0
+                        ? `(${formatNumber(data.productionPerSecond)} BB/s)`
                         : '';
-                } else if (data.message==='Nicht eingeloggt') {
+                } else if (data.message === 'Nicht eingeloggt') {
                     clearInterval(updateInterval);
                 }
             } catch (e) {

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -73,6 +73,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 const data = await response.json();
                 if (data.success) {
                     currencyElement.textContent = formatNumber(data.newAmount);
+                    currencyElement.dataset.rawAmount = data.newAmount;
                     productionRateElement.textContent = data.productionPerSecond > 0
                         ? `(${formatNumber(data.productionPerSecond)} BB/s)`
                         : '';
@@ -146,11 +147,11 @@ async function increaseCurrency() {
         const data = await response.json();
 
         if (data.success) {
-            // Anzeige direkt mit dem neuen Betrag vom Server aktualisieren
-            const formattedAmount = parseFloat(data.newAmount).toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+            // Rohwert speichern und mit formatNumber-Abkürzung anzeigen
             const currencyElement = document.getElementById('currency');
             if (currencyElement) {
-                currencyElement.textContent = formattedAmount;
+                currencyElement.dataset.rawAmount = data.newAmount;
+                currencyElement.textContent = formatNumber(data.newAmount);
             }
         } else {
             console.error('API Fehler beim Klicken:', data.message);
@@ -298,7 +299,7 @@ async function kaufUpgrade(upgradeId) { // Funktion muss async sein für await
     // Preisberechnung clientseitig nur zur Vorabprüfung (optional, aber gut für UX)
     let clientSidePreisCheck = kalkPreis(upgrade.basispreis, upgrade.level, upgrade.id);
     const currencyElement = document.getElementById('currency');
-    const currentDisplayAmount = parseFloat(currencyElement.textContent.replace(/\./g, '').replace(/,/, '.')) || 0;
+    const currentDisplayAmount = parseFloat(currencyElement.dataset.rawAmount) || 0;
 
     if (clientSidePreisCheck > currentDisplayAmount) { 
         alert("Nicht genug BB für dieses Upgrade! (Client-Check)");

--- a/src/config/dbAccess.php
+++ b/src/config/dbAccess.php
@@ -179,7 +179,8 @@
         $stmt = $db->prepare("SELECT amount FROM beute_batzen WHERE user_id = ?");
         $stmt->bind_param("i", $userId);
         $stmt->execute();
-        return $stmt->get_result()->fetch_assoc()['amount'] ?? 0;
+        $value = $stmt->get_result()->fetch_assoc()['amount'] ?? 0;
+        return round((float)$value, 2);
     }
 
     // NEUE FUNKTION: Speichert oder aktualisiert den Währungsstand eines Benutzers
@@ -190,7 +191,7 @@
             return false;
         }
         // Konvertiere zu float, um Kompatibilität mit DB zu gewährleisten
-        $amountFloat = floatval($amount);
+        $amountFloat = round(floatval($amount), 2); // auf 2 Dezimalstellen runden
 
         $stmt = $db->prepare("
             INSERT INTO beute_batzen (user_id, amount)
@@ -378,7 +379,7 @@
 
         // 2. Aktualisiere beute_batzen mit der Produktion der letzten Sekunde
         // Wir gehen davon aus, dass diese Funktion ca. jede Sekunde aufgerufen wird.
-        $amountToAdd = $totalProductionPerSecond; // Produktion pro Sekunde
+        $amountToAdd = round($totalProductionPerSecond, 2); // auf 2 Dezimalstellen runden
 
         if ($amountToAdd > 0) {
             // Verwende INSERT ... ON DUPLICATE KEY UPDATE für Effizienz

--- a/src/content/user/statistics.php
+++ b/src/content/user/statistics.php
@@ -25,7 +25,7 @@ $statistics = fetchUserStatistics($db);
               <?php foreach ($statistics as $stat): ?>
                   <tr>
                       <th scope="row"><?php echo htmlspecialchars($stat['username']); ?></th>
-                      <td><span class="format-number" data-value="<?php echo htmlspecialchars($stat['geld']); ?>"></span> Batzen</td>
+                      <td><span class="format-number" data-value="<?php echo round($stat['geld'], 2); ?>"></span> Batzen</td>
                       <td><?php echo htmlspecialchars($stat['upgrades']); ?></td>
                   </tr>
               <?php endforeach; ?>

--- a/src/content/user/statistics.php
+++ b/src/content/user/statistics.php
@@ -25,7 +25,7 @@ $statistics = fetchUserStatistics($db);
               <?php foreach ($statistics as $stat): ?>
                   <tr>
                       <th scope="row"><?php echo htmlspecialchars($stat['username']); ?></th>
-                      <td><?php echo htmlspecialchars($stat['geld']); ?></td>
+                      <td><span class="format-number" data-value="<?php echo htmlspecialchars($stat['geld']); ?>"></span> Batzen</td>
                       <td><?php echo htmlspecialchars($stat['upgrades']); ?></td>
                   </tr>
               <?php endforeach; ?>
@@ -35,3 +35,22 @@ $statistics = fetchUserStatistics($db);
 </section>
 <?php require_once('../../includes/footer.php'); ?>
 <script src="../../../../assets/js/script.js"></script>
+<script>
+// Formatiert alle Elemente mit der Klasse "format-number"
+document.addEventListener('DOMContentLoaded', function() {
+    if (typeof window.formatNumber === 'function') {
+        document.querySelectorAll('.format-number').forEach(function(element) {
+            const value = parseFloat(element.dataset.value);
+            element.textContent = window.formatNumber(value);
+        });
+    } else {
+        document.querySelectorAll('.format-number').forEach(function(element) {
+            const value = parseFloat(element.dataset.value);
+            element.textContent = value.toLocaleString('de-DE', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            });
+        });
+    }
+});
+</script>

--- a/src/index.php
+++ b/src/index.php
@@ -17,16 +17,21 @@ require_once('includes/nav.php');
         <img id="click_button" src="/assets/img/gamearea_platzhalter.png" alt="Dungeon‑Spielbereich">
     </section>
     
+    <!-- Currency display with simplified structure -->
+    <div class="row justify-content-center mt-3">
+        <div class="col-md-6 text-center">
+            <div id="currency-display" class="currency-display">
+                <span id="currency-label">Beute Batzen: </span>
+                <span id="currency">0.00</span>
+                <span id="proSekunde"></span>
+            </div>
+        </div>
+    </div>
+    
     <!-- Toggle Button fuer Side Panels -->
     <button id="toggle-side-panels" class="btn btn-primary d-lg-none">☰</button>
     
     <div id="side-panels" class="d-lg-flex flex-lg-column mt-4">
-        <div id="currency-display" class="currency-display">
-            <span id="currency-label">Beute Batzen: </span>
-            <span id="currency">0.00</span>
-            <span id="currency-label"> BB</span>
-            <span id="proSekunde"></span>
-        </div>
         <div class="side-panel mb-3">
             <h2>Stats</h2>
             <div class="stat-display mt-3 mb-3">


### PR DESCRIPTION
BB Anzeige verbesserung für Desktop und Mobile + kalkulation von wissenschaftlichen Kürzeln.

Zusammenfassung der Änderungen:
Datenbankschema: beute_batzen.amount von bigint zu double geändert
JavaScript: formatNumber-Funktion für einheitliche Formatierung großer Zahlen hinzugefügt
API: Unformatierte Rohdaten an das Frontend übermittelt
HTML-Struktur: Currency-Display für bessere Sichtbarkeit auf mobilen Geräten neu positioniert
CSS: Styling der Währungsanzeige vereinfacht

