### PR TITLE
US 104 User Session wird zerstört sobald gesperrt

### DIFF
--- a/src/api/update_currency.php
+++ b/src/api/update_currency.php
@@ -14,9 +14,9 @@ if (!isset($_SESSION['user']['id'])) {
     exit;
 }
 
-if (fetchUserLocked($db, $userId);) {
+if (fetchUserLocked($db, $_SESSION['user']['id'])) {
     session_destroy();
-    echo json_encode(['success' => false, 'message' => 'Account wurde gesperrt.']);
+    echo json_encode(['success' => false, 'message' => 'Account wurde gesperrt']);
     exit;
 }
 

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -110,6 +110,8 @@ async function updateCurrencyDisplay() {
             throw new Error(`HTTP ${response.status}`);
         }
         const data = await response.json();
+        console.log(data);
+        console.log(data.message);
         if (data.success) {
             const oldAmount = parseFloat(currencyElement.dataset.rawAmount) || 0;
             currencyElement.textContent = formatNumber(data.newAmount);
@@ -136,6 +138,10 @@ async function updateCurrencyDisplay() {
             aktualisiereUpgradeHervorhebung();
         } else if (data.message === 'Nicht eingeloggt') {
             clearInterval(updateInterval);
+        } else if (data.message === 'Account wurde gesperrt') {
+            clearInterval(updateInterval);
+            alert('Dein Account wurde gesperrt. Bitte kontaktiere den Support.');
+            window.location.href = '/profil'; // Weiterleitung zur Startseite
         }
     } catch (e) {
         console.error('Fehler beim Abrufen der Währung:', e);

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -141,7 +141,7 @@ async function updateCurrencyDisplay() {
         } else if (data.message === 'Account wurde gesperrt') {
             clearInterval(updateInterval);
             alert('Dein Account wurde gesperrt. Bitte kontaktiere den Support.');
-            window.location.href = '/profil'; // Weiterleitung zur Startseite
+            window.location.href = '/impressum'; // Weiterleitung zum Impressum
         }
     } catch (e) {
         console.error('Fehler beim Abrufen der Währung:', e);


### PR DESCRIPTION
Sobald User von Admin gesperrt wird, wird er innerhalb von einer Sekunde ausgeloggt, Session zerstört und zum Login redirectet